### PR TITLE
Przeniesienie mailSettings do appSettings

### DIFF
--- a/v3.0/Source/Core.Test/Infrastructure/Others/EmailSenderFixture.cs
+++ b/v3.0/Source/Core.Test/Infrastructure/Others/EmailSenderFixture.cs
@@ -16,7 +16,8 @@ namespace Kigg.Core.Test
         public EmailSenderFixture()
         {
             _file = new Mock<IFile>();
-            _emailSender = new EmailSender("MailTemplates", true, settings.Object, _file.Object);
+            var config = new Mock<IConfigurationManager>();
+            _emailSender = new EmailSender("MailTemplates", true, settings.Object, _file.Object, config.Object);
         }
 
         public override void Dispose()

--- a/v3.0/Source/Core/Infrastructure/Mail/EmailSender.cs
+++ b/v3.0/Source/Core/Infrastructure/Mail/EmailSender.cs
@@ -18,17 +18,21 @@
         private readonly bool _enableSsl;
         private readonly IConfigurationSettings _settings;
         private readonly IFile _file;
+        private readonly IConfigurationManager _configurationManager;
 
-        public EmailSender(string templateDirectory, bool enableSsl, IConfigurationSettings settings, IFile file)
+        public EmailSender(string templateDirectory, bool enableSsl, IConfigurationSettings settings, IFile file,
+            IConfigurationManager configurationManager)
         {
             Check.Argument.IsNotEmpty(templateDirectory, "templateDirectory");
             Check.Argument.IsNotNull(settings, "settings");
             Check.Argument.IsNotNull(file, "file");
+            Check.Argument.IsNotNull(configurationManager, "configurationManager");
 
             _templateDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, templateDirectory);
             _enableSsl = enableSsl;
             _settings = settings;
             _file = file;
+            _configurationManager = configurationManager;
         }
 
         public void SendRegistrationInfo(string email, string userName, string password, string activateUrl)
@@ -297,10 +301,15 @@
         {
             try
             {
-                SmtpClient smtp = new SmtpClient
-                                      {
-                                          EnableSsl = _enableSsl
-                                      };
+                var smtp = new SmtpClient
+                {
+                    Host = _configurationManager.AppSettings["mailServer"],
+                    Port = int.Parse(_configurationManager.AppSettings["mailPort"]),
+                    Credentials = new System.Net.NetworkCredential(
+                        _configurationManager.AppSettings["mailUser"],
+                        _configurationManager.AppSettings["mailPass"]),
+                    EnableSsl = _enableSsl
+                };
 
                 smtp.Send(mail);
             }

--- a/v3.0/Source/Web/Web.config
+++ b/v3.0/Source/Web/Web.config
@@ -17,10 +17,14 @@
     <add key="MiniProfilerEnabled" value="false" />
     <add key="recaptcha-secret-key" value="__captcha_secret_key__" />
     <add key="recaptcha-public-key" value="__captcha_public_key__" />
+    <add key="mailServer" value="__mailServer__" />
+    <add key="mailPort" value="587" />
+    <add key="mailUser" value="__mailUser__" />
+    <add key="mailPass" value="__mailPass__" />
   </appSettings>
   <connectionStrings>
     <clear />
-    <add name="dotnetomaniak" connectionString="Data Source=__sql_server__;Database=__sql_db_name__;User Id=__sql_user__;Password=__sql_password__;MultipleActiveResultSets=true" providerName="System.Data.SqlClient" />
+    <add name="dotnetomaniak" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=dotnetomaniak;Integrated Security=SSPI;" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <!-- The uri section is necessary to turn on .NET 3.5 support for IDN (international domain names),
        which is necessary for OpenID urls with unicode characters in the domain/host name. 
@@ -424,6 +428,9 @@
                   <dependency />
                 </param>
                 <param name="file" parameterType="IFile">
+                  <dependency />
+                </param>
+                <param name="configurationManager" parameterType="IConfigurationManager">
                   <dependency />
                 </param>
               </constructor>
@@ -2084,11 +2091,6 @@
     <settings>
       <servicePointManager expect100Continue="false" />
     </settings>
-    <mailSettings>
-      <smtp from="admin@dotnetomaniak.pl" deliveryMethod="Network">
-        <network host="__mail_server__" port="587" userName="admin@dotnetomaniak.pl" password="__mail_password__" />
-      </smtp>
-    </mailSettings>
   </system.net>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.


### PR DESCRIPTION
Ponieważ tylko sekcje app settings i connection strings mogą być "nadpisywane" przez Azure Web App to dzięki temu namiary na email nie muszą być trzymane ani w repo ani w definicji build.