### PR TITLE
Contentowe pierdółki - Dodanie linka do repo w /about i /faq

### DIFF
--- a/v3.0/Source/Web/Views/Support/About.aspx
+++ b/v3.0/Source/Web/Views/Support/About.aspx
@@ -17,6 +17,7 @@
     <p>Jeśli technologia .NET nie jest Ci obojętna - przyłącz się do nas i zamieszczaj artykuły.</p>
     <p>Obecnie w rozwoju pomagają:</p>
     <ul>
+    <li><a href="https://stapp.space">Piotr Stapp</a></li>
 	<li><a href="http://pawlos.blogspot.com">Paweł Łukasik</a></li>
     <li>Paweł Kubacki</li>
     </ul>
@@ -27,6 +28,6 @@
 	<li>Michał Jałbrzykowski (grafika)</li>
 	<li>Łukasz Wawrzyniak</li>
     </ul>
-    <p>Chcesz nam pomóc? Napisz do <a href="<%= Url.RouteUrl("Contact") %>">nas</a>.
+    <p>Chcesz nam pomóc? Napisz do <a href="<%= Url.RouteUrl("Contact") %>">nas</a> lub pomóż nam rozwijać projekt na <a href="https://github.com/dotnetomaniak/dotnetomaniak" target="_blank" rel="external noopener noreferrer">GitHubie</a>.</p>
     </div>
 </asp:Content>

--- a/v3.0/Source/Web/Views/Support/Faq.aspx
+++ b/v3.0/Source/Web/Views/Support/Faq.aspx
@@ -222,12 +222,12 @@
                         Server</a> ICSModule.</li>
                 </ul>
                 Wymienione komponenty mają możliwość pełnej zmiany ustawień licznika <em>Promuj</em>
-                i dostepny kod źródłowy. Aby ściągnąć wejdź na stronę <a href="http://www.codeplex.com/Kigg/Release/ProjectReleases.aspx"
-                    target="_blank">release'ów Kigg</a> i postępuj zgodnie z instrukcjami.
+                i dostepny kod źródłowy do wglądu. Aby ściągnąć wejdź na naszego <a href="https://github.com/dotnetomaniak/dotnetomaniak" target="_blank" rel="external noopener noreferrer">GitHuba</a> lub na stronę <a href="https://archive.codeplex.com/?p=kigg"
+                    target="_blank" rel="external noopener noreferrer">archiwum release'ów Kigg na CodePlex</a>.
                 <br />
                 <pre style="background-color: #ddd; font-size: 10px; margin-top: 5px;">
-<code>&lt;div class=&quot;kigg&quot;&gt; &lt;a rev=&quot;vote-for&quot; href=&quot;http://dotnetomaniak.pl/Submit?url=URL&quot;&gt;
-&lt;img alt=&quot;Promuj&quot; src=&quot;http://dotnetomaniak.pl/image.axd?url=URL&quot;
+<code>&lt;div class=&quot;kigg&quot;&gt; &lt;a rev=&quot;vote-for&quot; href=&quot;https://dotnetomaniak.pl/Submit?url=URL&quot;&gt;
+&lt;img alt=&quot;Promuj&quot; src=&quot;https://dotnetomaniak.pl/image.axd?url=URL&quot;
 style=&quot;border:0px&quot;/&gt; &lt;/a&gt; &lt;div&gt;</code></pre>
             </div>
         </li>


### PR DESCRIPTION
Drobiazgi, które rzuciły mi się w oczy podczas przeglądania projektu.

- Dodałem @ptrstpp950 w `/About`
- Dodałem info o możliwości wsparcia projektu na GitHubie z linkiem do repo w `/About` i `/Faq`
- Poprawiłem linki w buttonach na https
- W opisie rozwijania własnych wtyczek do oddawania głosów podmieniłem link do Kigga na kierujący do archiwum oraz usunąłem fragment "i postępuj zgodnie z instrukcjami" ponieważ Codeplex padł +/- rok temu i instrukcje już nie istnieją. Moim zdaniem link do nich można całkowicie usunąć.