### PR TITLE
Giving a bit more room for Continue with button

### DIFF
--- a/v3.0/Source/Web/Views/Shared/MembershipBox.ascx
+++ b/v3.0/Source/Web/Views/Shared/MembershipBox.ascx
@@ -81,7 +81,7 @@
                 <div class="add-article-row">
                     <div class="add-row2">
                         <div class="fb-login-button" data-onlogin="checkLoginState()" data-max-rows="1" 
-                             data-size="large" data-button-type="login_with" data-show-faces="false" data-auto-logout-link="false" data-use-continue-as="true"></div>
+                             data-size="large" data-width="300" data-button-type="login_with" data-show-faces="false" data-auto-logout-link="false" data-use-continue-as="true"></div>
                     </div>
                     <br />
                 </div>


### PR DESCRIPTION
Fixing #53 

Dodanie rozmiaru do przycisku z Fb powinno naprawić problem ucinania przynajmniej dla większości przypadków. Chyba nie ma jakiegoś uniwersalnego rozwiązania aby to naprawić.