### PR TITLE
Dodanie integracji z OneSignal

### DIFF
--- a/v3.0/Source/Web/BootstrapperTasks/RegisterRoutes.cs
+++ b/v3.0/Source/Web/BootstrapperTasks/RegisterRoutes.cs
@@ -35,6 +35,11 @@ namespace Kigg.Web
             _routes.IgnoreRoute("{file}.xml");
             _routes.IgnoreRoute("Data/Thumbnails/{file}.png");
 
+            //Ignore OneSignal's files
+            _routes.IgnoreRoute("OneSignalSDKWorker.js");
+            _routes.IgnoreRoute("OneSignalSDKUpdaterWorker.js");
+            _routes.IgnoreRoute("manifest.json");
+
             // Ignore axd files such as assest, image, sitemap etc
             _routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
 

--- a/v3.0/Source/Web/OneSignalSDKUpdaterWorker.js
+++ b/v3.0/Source/Web/OneSignalSDKUpdaterWorker.js
@@ -1,0 +1,1 @@
+importScripts('https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js');

--- a/v3.0/Source/Web/OneSignalSDKWorker.js
+++ b/v3.0/Source/Web/OneSignalSDKWorker.js
@@ -1,0 +1,1 @@
+importScripts('https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js');

--- a/v3.0/Source/Web/Views/Shared/SiteTemplate.Master
+++ b/v3.0/Source/Web/Views/Shared/SiteTemplate.Master
@@ -319,6 +319,17 @@
         window.appInsights=appInsights;
         appInsights.trackPageView();
     </script>
+
+    <link rel="manifest" href="/manifest.json" />
+    <script src="https://cdn.onesignal.com/sdks/OneSignalSDK.js"></script>
+    <script>
+      var OneSignal = window.OneSignal || [];
+      OneSignal.push(function() {
+        OneSignal.init({
+          appId: "c6cdd15b-64cd-4513-947a-ea62d4959bd7",
+        });
+      });
+    </script>
 </head>
 <body>
 

--- a/v3.0/Source/Web/manifest.json
+++ b/v3.0/Source/Web/manifest.json
@@ -1,0 +1,4 @@
+{
+  "gcm_sender_id": "482941778795",
+  "gcm_sender_id_comment": "Do not change the GCM Sender ID"
+}


### PR DESCRIPTION
Dodałem integrację z OneSignal. Wrzucenie jej na produkcję przy obecnych ustawieniach będzie skutkowało wyświetlaniem przeglądarkowej prośby o zgodę na powiadomienia (na wszystkich przeglądarkach oprócz Safari), jak poniżej:
![obraz](https://user-images.githubusercontent.com/46908200/55360147-df23aa80-54d3-11e9-8d18-d82c8b50623d.png)

Po wyrażeniu zgody użytkownik otrzyma powitalne powiadomienie:
![obraz](https://user-images.githubusercontent.com/46908200/55360252-17c38400-54d4-11e9-8e37-17cfad62d350.png)

Wygląd i zachowanie prompta można zmieniać z perspektywy panelu OneSignal.