### PR TITLE
Change registration type + small fixes

### DIFF
--- a/v3.0/Source/Kigg.Infrastructure.EF/DomainObjectFactory.cs
+++ b/v3.0/Source/Kigg.Infrastructure.EF/DomainObjectFactory.cs
@@ -100,6 +100,7 @@ namespace Kigg.Infrastructure.EF
                 UniqueName = title.Trim().ToLegalUrl().RemovePolishNationalChars(),
                 Title = title.Trim(),
                 HtmlDescription = description.Trim(),
+                TextDescription = description.StripHtml().Trim(),
                 Url = url,
                 IPAddress = fromIpAddress,
                 CreatedAt = now,

--- a/v3.0/Source/Web/Jobs/AwardBadgeJob.cs
+++ b/v3.0/Source/Web/Jobs/AwardBadgeJob.cs
@@ -32,11 +32,8 @@ namespace Kigg.Web.Jobs
 
             try
             {
-                using (var context =
-                    IoC.Resolve<DotnetomaniakContext>())
-                {
-                    AwardBadges(context);
-                }
+                var context = IoC.Resolve<DotnetomaniakContext>();
+                AwardBadges(context);
             }
             catch (Exception e)
             {

--- a/v3.0/Source/Web/Web.config
+++ b/v3.0/Source/Web/Web.config
@@ -2000,7 +2000,7 @@
           <type name="FacebookBadge" type="IBootstrapperTask" mapTo="FacebookBadge">
             <lifetime type="Singleton" />
           </type>
-          <type name="DotnetomaniakContext" type="DotnetomaniakContext" mapTo="DotnetomaniakContext">
+          <type type="DotnetomaniakContext">
             <lifetime type="PerWebRequest" />
           </type>
         </types>


### PR DESCRIPTION
- Poprawiłem (za wskazówką @pawlos , dzięki!) rejestrację Contextu, dzięki temu jest `scoped` a nie `transient`.
- fixnąłem buga z dodawaniem story (nie wiem czemu ten TextDescription gdzieś wyleciał, takią jego implementację znalazłem [tu](https://github.com/dotnetomaniak/dotnetomaniak/blob/master/v3.0/Source/LinqToSql/DomainObjects/Story.cs#L457), mam nadzieję że poprawnie, zobacz proszę @ptrstpp950 
- usunąłem dispose na Context'cie, bo wywalał czasami context za szybko, wydaje mi się, że z uwagi na to iż jest to `scoped` teraz to nie ma potrzeby tego usinga